### PR TITLE
Adicionar endpoint /ping para health check público

### DIFF
--- a/src/main/java/com/sistemaguincho/gestaoguincho/auth/security/SecurityConfig.java
+++ b/src/main/java/com/sistemaguincho/gestaoguincho/auth/security/SecurityConfig.java
@@ -45,6 +45,9 @@ public class SecurityConfig {
                         // rotas públicas
                         .requestMatchers("/api/auth/**").permitAll()
 
+                        // Endpoint de health check
+                        .requestMatchers("/ping").permitAll()
+
                         // Permite que qualquer um visualize e filtre a lista de chamados
                         .requestMatchers(HttpMethod.GET, "/api/chamados/**").permitAll()
 

--- a/src/main/java/com/sistemaguincho/gestaoguincho/health/HealthCheckController.java
+++ b/src/main/java/com/sistemaguincho/gestaoguincho/health/HealthCheckController.java
@@ -1,0 +1,13 @@
+package com.sistemaguincho.gestaoguincho.health;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "OK";
+    }
+}


### PR DESCRIPTION
**O que foi feito**
- Criado o endpoint `/ping` em HealthCheckController.
- Endpoint retorna 200 OK e é público, não requer autenticação.
- Permite monitoramento da aplicação por serviços externos (ex.: UptimeRobot).

**Por que foi feito**
- Garantir que a aplicação Render permaneça ativa no plano gratuito.
- Evitar erros 403 ao tentar acessar o endpoint para pings automáticos.

**Como testar**
1. Rodar a aplicação localmente e acessar: http://localhost:8080/ping
   - Deve retornar "OK" com status 200.
2. Acessar o deploy no Render: https://seuapp.onrender.com/ping
   - Deve retornar "OK" com status 200.
3. Verificar que a requisição não exige JWT ou autenticação.